### PR TITLE
Center align headers

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,3 +24,16 @@
 ::before {
   box-sizing: inherit;
 }
+
+
+h1 {
+    text-align: center;
+}
+
+h2 {
+    text-align: center;
+}
+
+h3 {
+    text-align: center;
+}


### PR DESCRIPTION
This ensures that headers are still centered even if the container gets so small that the text wraps.